### PR TITLE
Set picto by class

### DIFF
--- a/compare.html
+++ b/compare.html
@@ -5,8 +5,8 @@
         <meta charset='utf-8'/>
         <title>Compare your style</title>
         <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no'/>
-        <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.45.0/mapbox-gl.js'></script>
-        <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.45.0/mapbox-gl.css' rel='stylesheet'/>
+        <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.46.0/mapbox-gl.js'></script>
+        <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.46.0/mapbox-gl.css' rel='stylesheet'/>
         <style>
             body {
                 margin: 0;

--- a/debug.html
+++ b/debug.html
@@ -5,8 +5,8 @@
         <meta charset='utf-8'/>
         <title>Debug your style</title>
         <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no'/>
-        <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.45.0/mapbox-gl.js'></script>
-        <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.45.0/mapbox-gl.css' rel='stylesheet'/>
+        <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.46.0/mapbox-gl.js'></script>
+        <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.46.0/mapbox-gl.css' rel='stylesheet'/>
         <script src='http://mapbox-gl-inspect.lukasmartinelli.ch/dist/mapbox-gl-inspect.min.js'></script>
         <link href='http://mapbox-gl-inspect.lukasmartinelli.ch/dist/mapbox-gl-inspect.css' rel='stylesheet'/>
 

--- a/task/icons/index.js
+++ b/task/icons/index.js
@@ -32,6 +32,17 @@ module.exports = (options, style) => {
           colorsCases.push(icon.color)
         }
 
+      } else if (icon.class) {
+        iconsCases.push(["==",
+          ["get", "class"],
+          icon.class])
+        iconsCases.push(icon.iconName)
+        if (icon.color) {
+          colorsCases.push(["==",
+            ["get", "class"],
+            icon.class])
+          colorsCases.push(icon.color)
+        }
       } else {
         iconsCases.push(["==",
           ["get", "subclass"],


### PR DESCRIPTION
This PR allows to set picto and color for a `class` (without specifying the `subclass`).

This way, you can set default picto for class without using the subclass.

For instance:
```yml
  - class: place_of_worship
    subclass: christian
    iconName: religious-christian-11
    color: '#8A9CF6'
  - class: place_of_worship
    iconName: place-of-worship-11
    color: '#8A9CF6'
```
will set the `religious-christian-11` icon to the place_of_worship with subclass = christian and the `place-of-worship-11`picto for all other place_of_worships

(And also update to mapboxgl js 0.46.0)